### PR TITLE
Metadata Schema for BAM reference dataset

### DIFF
--- a/PP18_dataset_metadata_Schema.json
+++ b/PP18_dataset_metadata_Schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/kit-data-manager/Metadata-Schemas-for-Materials-Science/edit/main/PP18_Schema.json",
+  "type": "object",
+  "description": "This JSON Schema describes the metadata of the reference dataset by BAM It contains the metadata of the results of ASTM E139 -11 creep tests on a reference material of Nimonic 75 nickel-base alloy",
+  "title": "Metadata of BAM reference data: results of ASTM E139 -11 creep tests on a reference material of Nimonic 75 nickel-base alloy",
+  "properties": {
+    "access_right_category": {
+      "type": "string",
+      "description": "(Optional) - to be given as success if the document is open-access"
+    },
+    "doi": {
+      "type": "string",
+      "description": "(Required) - DOI of the document"
+    },
+    "description": {
+      "type": "string",
+      "description": "Elaborate Information on the data"
+    },
+    "language": {
+      "type": "string",
+      "description": "(Required) - Language of the Document"
+    },
+    "license": {
+        "type":"object",
+        "description": "(Required) - Describes the License under which the documents are protected",
+        "properties":{
+            "id": {
+                "type": "string",
+                "description": "(Required) - id of the license, eg. CC-BY-4.0"
+              }
+        },
+        "required":[
+            "id"
+        ]
+    },
+    "notes": {
+      "type": "string",
+      "description": "(Optional) - Additional notes"
+    },
+    "relations": {
+      "type": "object",
+      "description": "(Required) - Describes the relations the document has to other documents and versions",
+      "properties": {
+        "version": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "count": {
+                "type": "number",
+                "description": "(Required) - No. of versions at present"
+              },
+              "index": {
+                "type": "number",
+                "description": "(Required) - Index of the version"
+              },
+              "parent": {
+                "type": "object",
+                "description": "(Optional) - Details about the parent version",
+                "properties": {
+                  "pid_type": {
+                    "type": "string",
+                    "description": "(Optional) - Type of the PID, eg. recid"
+                  },
+                  "pid_value": {
+                    "type": "string",
+                    "description": "(Optional) -Value of the PID"
+                  }
+                }
+              },
+              "is_last": {
+                "type": "boolean",
+                "description": "(Required) - Is this version the latest one?"
+              },
+              "last_child": {
+                "type": "object",
+                "description": "(Optional) - Details of the ltest child version",
+                "properties": {
+                  "pid_type": {
+                    "type": "string",
+                    "description": "(Optional) - Type of the PID, eg. recid"
+                  },
+                  "pid_value": {
+                    "type": "string",
+                    "description": "(Optional) -Value of the PID"
+                  }
+                }
+              }
+            },
+            "required":[
+                "count",
+                "index",
+                "is_last"
+            ]
+          }
+        }
+      },
+      "required": [
+        "version"
+      ]
+    },
+    "communities": {
+      "type": "array",
+      "description":"Details about a collaborative community to which the data belongs",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description":"ID of the community as a string. eg. bam"
+          }
+        }
+      }
+    },
+    "version": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "publication_date": {
+      "type": "string",
+      "pattern": "(\\d{4}-\\d{2}-\\d{2})"
+    },
+    "creators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "orcid": {
+            "type": "string",
+            "description": "(Optional) - Open Researcher and Contributor ID",
+            "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[X0-9]{1}$"
+          },
+          "affiliation": {
+            "type": "string",
+            "description": "(Required) - Details of the institution to which the creator is affiliated"
+          },
+          "name": {
+            "type": "string",
+            "description": " (Required) - Full name of the creator in the format (Family Name, Given Name)"
+          }
+        },
+        "required": [
+          "name",
+          "affiliation"
+        ]
+      }
+    },
+    "access_right": {
+      "type": "string",
+      "description": " (Required) - Type of access right. e.g. open"
+    },
+    "resource_type": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": " (Required) - Type of the resource. eg. dataset, image"
+        },
+        "title": {
+          "type": "string",
+          "description": " (Required) - Title of the resource. eg. Dataset"
+        }
+      },
+      "required": [
+        "type",
+        "title"
+      ]
+    },
+    "related_identifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "description": " (Required) - Type of the identifier, eg. DOI"
+          },
+          "identifier": {
+            "type": "string",
+            "description": " (Required) - Value of the identifier"
+          },
+          "relation": {
+            "type": "string",
+            "description": " (Required) - Relation of the related resource, eg: isVersionOf"
+          }
+        },
+        "required": [
+          "scheme",
+          "identifier",
+          "relation"
+        ]
+      }
+    }
+  },
+  "required": [
+    "version",
+    "creators",
+    "access_right",
+    "resource_type",
+    "publication_date",
+    "language",
+    "description",
+    "doi",
+    "license"
+  ]
+}


### PR DESCRIPTION
This schema describes the metadata contained in the JSON export of the BAM (PP18) dataset from zenodo at https://zenodo.org/record/7764161