### PR TITLE
Fix PR comments breaking on very long reports

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -59,7 +59,7 @@ jobs:
           echo '**Tag Prefix:** `${{ matrix.tagPrefix }}`' >> message.txt
           echo '**Latest Tag for Comparison:** `${{ env.previousVersion }}`' >> message.txt
           echo '' >> message.txt
-          printf "%s" "${{ steps.schema_check_step.outputs.message }}" >> message.txt
+          cat <<'EOF' ${{ steps.schema_check_step.outputs.message }} EOF } > message.txt
       - name: Post summary to PR
         uses: peter-evans/create-or-update-comment@v4
         with:

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -52,15 +52,17 @@ jobs:
           createDiff: true
           previousVersion: ${{ env.previousVersion }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Write message to file
+        run: |
+          echo '## 📋 Schema Check Report' > message.txt
+          echo '**Schema Path:** `${{ matrix.schemaPath }}`' >> message.txt
+          echo '**Tag Prefix:** `${{ matrix.tagPrefix }}`' >> message.txt
+          echo '**Latest Tag for Comparison:** `${{ env.previousVersion }}`' >> message.txt
+          echo '' >> message.txt
+          printf "%s" "${{ steps.schema_check_step.outputs.message }}" >> message.txt
       - name: Post summary to PR
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## 📋 Schema Check Report
-            **Schema Path:** `${{ matrix.schemaPath }}`
-            **Tag Prefix:** `${{ matrix.tagPrefix }}`
-            **Latest Tag for Comparison:** `${{ env.previousVersion }}`
-      
-            ${{ steps.schema_check_step.outputs.message }}
+          body-path: message.txt

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -52,14 +52,18 @@ jobs:
           createDiff: true
           previousVersion: ${{ env.previousVersion }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Write message to file
+      - name: Write report header to file
         run: |
           echo '## 📋 Schema Check Report' > message.txt
           echo '**Schema Path:** `${{ matrix.schemaPath }}`' >> message.txt
           echo '**Tag Prefix:** `${{ matrix.tagPrefix }}`' >> message.txt
           echo '**Latest Tag for Comparison:** `${{ env.previousVersion }}`' >> message.txt
           echo '' >> message.txt
-          cat <<'EOF' ${{ steps.schema_check_step.outputs.message }} EOF } > message.txt
+      - name: Append schema output
+        run: |
+          cat >> message.txt <<EOF 
+          ${{ steps.schema_check_step.outputs.message }}
+          EOF
       - name: Post summary to PR
         uses: peter-evans/create-or-update-comment@v4
         with:


### PR DESCRIPTION
Added a step to write schema check report to a file to handle long reports, and updated the PR comment to use the report file instead of inline text.