### PR TITLE
Fix ci pr comments

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -45,7 +45,7 @@ jobs:
           fi
       - name: JSON Schema Check
         id: schema_check_step
-        uses: kit-data-manager/json-schema-check-action@v0.0.8
+        uses: kit-data-manager/json-schema-check-action@main
         with:
           schemaPath: ${{ matrix.schemaPath }}
           validate: true
@@ -61,9 +61,7 @@ jobs:
           echo '' >> message.txt
       - name: Append schema output
         run: |
-          cat >> message.txt <<EOF 
-          ${{ steps.schema_check_step.outputs.message }}
-          EOF
+          cat "${{ steps.schema_check_step.outputs.message-file }}" >> message.txt
       - name: Upload comment body
         uses: actions/upload-artifact@v7.0.1
         with:


### PR DESCRIPTION
Currently PR comments are missing the diff section, issue addressed by this PR

Schema check workflow now uses main branch for json schema check action. We might be able to switch back to pinned versions in the future.